### PR TITLE
Adding support for DHCP name resolution so that routers and other com…

### DIFF
--- a/OpenGarage/espconnect.cpp
+++ b/OpenGarage/espconnect.cpp
@@ -62,7 +62,7 @@ void start_network_ap(const char *ssid, const char *pass) {
 	WiFi.disconnect();  // disconnect from router
 }
 
-void start_network_sta(const char *ssid, const char *pass, bool staonly) {
+void start_network_sta(const char *ssid, const char *pass, const char *hostname, bool staonly) {
 	if(!ssid || !pass) return;
 	DEBUG_PRINTLN(F("Sarting start_network_sta"));
 	if(staonly){
@@ -74,14 +74,17 @@ void start_network_sta(const char *ssid, const char *pass, bool staonly) {
 		if(WiFi.getMode() != WIFI_AP_STA) WiFi.mode(WIFI_AP_STA);
 		DEBUG_PRINTLN(F("Setting to AP+STA mode"));
 	}
+	if(hostname != NULL) {
+		WiFi.hostname(hostname);
+	}
 	WiFi.begin(ssid, pass);
 }
 
-void start_network_sta_with_ap(const char *ssid, const char *pass) {
-	start_network_sta(ssid, pass, false);
+void start_network_sta_with_ap(const char *ssid, const char *pass, const char *hostname) {
+	start_network_sta(ssid, pass, hostname, false);
 }
 
-void start_network_sta(const char *ssid, const char *pass) {
-	start_network_sta(ssid, pass, true);
+void start_network_sta(const char *ssid, const char *pass, const char *hostname) {
+	start_network_sta(ssid, pass, hostname, true);
 }
 

--- a/OpenGarage/espconnect.h
+++ b/OpenGarage/espconnect.h
@@ -47,7 +47,7 @@
 
 String scan_network();
 void start_network_ap(const char *ssid, const char *pass);
-void start_network_sta(const char *ssid, const char *pass);
-void start_network_sta_with_ap(const char *ssid, const char *pass);
+void start_network_sta(const char *ssid, const char *pass, const char *hostname = NULL);
+void start_network_sta_with_ap(const char *ssid, const char *pass, const char *hostname = NULL);
 
 #endif

--- a/OpenGarage/html/ap_home.html
+++ b/OpenGarage/html/ap_home.html
@@ -20,6 +20,7 @@
 <table>
 	<tr><td><b>WiFi SSID</b>:</td><td><input type='text' id='ssid'></td></tr>
 	<tr><td><b>WiFi Password</b>:</td><td><input type='password' id='pass'></td></tr>
+	<tr><td><b>Host Name:</b></td><td><input type='text' size=15 maxlength=32 id='host' data-mini='true' placeholder='(optional)'></td></tr>
 </table>
 <br>
 <b>Enable Cloud Connection</b>?<br>
@@ -77,7 +78,7 @@ function sf(){
 			dis_config(false);
 		}
 	};
-	var comm='cc?ssid='+encodeURIComponent(id('ssid').value)+'&pass='+encodeURIComponent(id('pass').value);
+	var comm='cc?ssid='+encodeURIComponent(id('ssid').value)+'&pass='+encodeURIComponent(id('pass').value)+'&host='+encodeURIComponent(id('host').value);
 	if(eval_cb('otc')||eval_cb('blynk')){
 		if(id('auth').value.length<32) {show_msg('Cloud token is too short!','red');return;}
 		comm+='&cld='+(eval_cb('blynk')?'blynk':'otc');

--- a/OpenGarage/htmls.h
+++ b/OpenGarage/htmls.h
@@ -20,6 +20,7 @@ input[type=password] {font-size: 12pt; height:28px;}
 <table>
 <tr><td><b>WiFi SSID</b>:</td><td><input type='text' id='ssid'></td></tr>
 <tr><td><b>WiFi Password</b>:</td><td><input type='password' id='pass'></td></tr>
+<tr><td><b>Host Name:</b></td><td><input type='text' size=15 maxlength=32 id='host' data-mini='true' placeholder='(optional)'></td></tr>
 </table>
 <br>
 <b>Enable Cloud Connection</b>?<br>
@@ -77,7 +78,7 @@ id('butt').innerHTML='Submit';
 dis_config(false);
 }
 };
-var comm='cc?ssid='+encodeURIComponent(id('ssid').value)+'&pass='+encodeURIComponent(id('pass').value);
+var comm='cc?ssid='+encodeURIComponent(id('ssid').value)+'&pass='+encodeURIComponent(id('pass').value)+'&host='+encodeURIComponent(id('host').value);
 if(eval_cb('otc')||eval_cb('blynk')){
 if(id('auth').value.length<32) {show_msg('Cloud token is too short!','red');return;}
 comm+='&cld='+(eval_cb('blynk')?'blynk':'otc');


### PR DESCRIPTION
…puters can connect without requiring mDNS.  This is especially helpful for routers that record the DHCP name in their ip table, now they will show the right name.  Also adding the hostname as an option in the ap_home page so you can specify the dhcp host name as soon as you connect to your network